### PR TITLE
Add static code analysis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: minimal
+
+jobs:
+  include:
+    - stage: Static Analysis
+      script: make check

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+any_bundle_SRC := $(wildcard $(CURDIR)/any-bundle/*.t)
+bundles_SRC := $(wildcard $(CURDIR)/bundles/*/*.t)
+
+SRC := $(any_bundle_SRC) $(bundles_SRC)
+
+bundles := $(notdir $(wildcard $(CURDIR)/bundles/*))
+
+# Static Code Analysis
+# ====================
+check_CHECKOPTS := --exclude=1091,2155
+check:
+	@echo "Shellcheck [All Bundles]:"
+	shellcheck -x $(check_CHECKOPTS) $(SRC)
+
+check_BUNDLES = $(addprefix check-,$(bundles))
+$(check_BUNDLES): bundle = $(patsubst check-%,%,$@)
+$(check_BUNDLES): tests = $(wildcard $(CURDIR)/bundles/$(bundle)/*.t)
+$(check_BUNDLES):
+	@echo "Shellcheck: [$(bundle)]:"
+	shellcheck -x $(check_CHECKOPTS) $(tests)
+
+check-any-bundle:
+	@echo "Shellcheck: [any-bundle]:"
+	shellcheck -x $(check_CHECKOPTS) $(any_bundle_SRC)


### PR DESCRIPTION
Use 'shellcheck' tool to run static code analysis on all test files.

Add a Makefile with the following targets:

- check               = Check syntax of all test files
- check-<bundle name> = Check syntax of all test files for a given
    bundle. Use 'any-bundle' as bundle name for 'any-bundle' tests.

Add a travis-ci file to run 'make check' on master branch and PRs.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>