### PR TITLE
[any-bundle] Lets unbreak 'ldconfig'

### DIFF
--- a/any-bundle/ldconfig.t
+++ b/any-bundle/ldconfig.t
@@ -1,14 +1,14 @@
 #!/usr/bin/env bats
 # *-*- Mode: sh; c-basic-offset: 8; indent-tabs-mode: nil -*-*
 
-@test "ldconfig returns no errors" {
-	LD_CACHE=$(mktemp)
-	run ldconfig -C "$LD_CACHE"
-	rm -f "$LD_CACHE"
+setup() {
+        TMP_CACHE=$(mktemp)
 }
 
-@test "ldconfig has no weird libraries" {
-	ldconfig -C -X
-	count=`ldconfig -C -X 2>&1`
-	[ "$count" == "" ]
+teardown() {
+        rm -f "${TMP_CACHE}"
+}
+
+@test "ldconfig returns no errors" {
+	ldconfig -X -C "${TMP_CACHE}"
 }


### PR DESCRIPTION
This test was basically destroyed.

The first basically masked the return code of 'ldconfig' therefore would
always return sucess (unless deleting the temp file happens to
file).

The second runs the same command twice, if ldconfig were to output an
error, the reminder of the test case is irrelevant since wont be
executed. Not only that, instead of calling ldconfig with '-X' was in
fact creating a cache file on current folder called '-X' :-/

There is no need to "count" (actually just to see if it is not empty)
the size of stderr output since ldconfig does the right and exits with
non-zero return code.

The problem the second tried to solve was only not captured by the
first test because the first was destroyed.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>