### PR TITLE
[any-bundle] Simplify journalclt assurance tests

### DIFF
--- a/any-bundle/journal.t
+++ b/any-bundle/journal.t
@@ -1,37 +1,25 @@
 #!/usr/bin/env bats
 
-@test "journal does not contain: Cannot open pixbuf loader module file" {
-    result="$(journalctl -b)"
-    result2="$(echo $result | grep  'Cannot open pixbuf loader module file' | wc -l )"
-    [ "$result2" == "0" ] 
+@test "Journal does not contains: 'Cannot open pixbuf loader module file'" {
+    ! journalctl -b | grep -c 'Cannot open pixbuf loader module file'
 }
 
-@test "journal does not contain: libGL error: failed to load driver" {
-    result="$(journalctl -b)"
-    result2="$(echo $result | grep  'libGL error: failed to load driver' | wc -l )"
-    [ "$result2" == "0" ] 
+@test "Journal does not contains: 'libGL error: failed to load driver'" {
+    ! journalctl -b | grep -c 'libGL error: failed to load driver'
 }
 
-@test "journal does not contain: Direct firmware load for regulatory.db failed with error" {
-    result="$(journalctl -b)"
-    result2="$(echo $result | grep  'Direct firmware load for regulatory.db failed with error' | wc -l )"
-    [ "$result2" == "0" ] 
+@test "Journal does not contains: 'Direct firmware load for regulatory.db failed with error'" {
+    ! journalctl -b | grep -c 'Direct firmware load for regulatory.db failed with error'
 }
 
-@test "journal does not contain: invalid key/value pair in file " {
-    result="$(journalctl -b)"
-    result2="$(echo $result | grep  'invalid key/value pair in file' | wc -l )"
-    [ "$result2" == "0" ] 
+@test "Journal does not contains: 'invalid key/value pair in file'" {
+    ! journalctl -b | grep -c 'invalid key/value pair in file'
 }
 
-@test "journal does not contain: Process '/usr/bin/alsactl restore 1' failed with exit code 99." {
-    result="$(journalctl -b)"
-    result2="$(echo $result | grep  '/usr/bin/alsactl' | grep 'failed with exit code' | wc -l )"
-    [ "$result2" == "0" ] 
+@test "Journal does not contains: 'Process '/usr/bin/alsactl restore 1' failed with exit code 99.'" {
+    ! journalctl -b | grep  '/usr/bin/alsactl' | grep -c 'failed with exit code'
 }
 
 @test "Failed to spawn Xwayland: Failed to execute child process" {
-    result="$(journalctl -b)"
-    result2="$(echo $result | grep  'Failed to spawn Xwayland: Failed to execute child process' | grep '/usr/bin/haswell/Xwayland' | wc -l )"
-    [ "$result2" == "0" ] 
+    ! journalctl -b | grep  'Failed to spawn Xwayland: Failed to execute child process' | grep -c '/usr/bin/haswell/Xwayland'
 }


### PR DESCRIPTION
Ideally we should have just a list of strings and either autogenerate
tests or run a single test that asserts all strings (making sure to
output failed entries in a human readable way).

But this is a start.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>