### PR TITLE
[makefile] Exclude SC2164

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all:
 
 # Static Code Analysis
 # ====================
-check_CHECKOPTS := --exclude=1091,2155 ${CHECKOPTS}
+check_CHECKOPTS := --exclude=1091,2155,2164 ${CHECKOPTS}
 check:
 	@echo "Shellcheck [All Bundles]:"
 	shellcheck -s bash -x $(check_CHECKOPTS) $(SRC)


### PR DESCRIPTION
Since bats always runs with 'set -e', that check would not matter.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>